### PR TITLE
правило для проверки симметричности значения и сеттера в useState

### DIFF
--- a/packages/eslint-config/.eslintrc.json
+++ b/packages/eslint-config/.eslintrc.json
@@ -86,6 +86,7 @@
         ],
         "no-negated-condition": "error",
         "react/no-array-index-key": "warn",
-        "react/button-has-type": "warn"
+        "react/button-has-type": "warn",
+        "react/hook-use-state": ["error", { "allowDestructuredState": true }]
     }
 }

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@37bytes/eslint-config",
-    "version": "2.0.0",
+    "version": "2.0.1",
     "description": "Default 37b eslint config",
     "main": ".eslintrc.json",
     "files": [


### PR DESCRIPTION
с опцией `"allowDestructuredState": true ` правило не будет выдавать ошибки для ситуаций типа: `const [{foo, bar, baz}, setFooBarBaz] = useState({foo: "bbb", bar: "aaa", baz: "qqq"})` (без него, как бы ни был назван сеттер будет выдавать ошибку)